### PR TITLE
Improving Overflow of Images over navbar

### DIFF
--- a/style.css
+++ b/style.css
@@ -93,6 +93,7 @@ html{
     justify-content: center;
     position: sticky;
     top: 0;
+    z-index: 1;
 }
 .background{
     background: rgba(0, 0, 0, 0.8) url(assets/bg3.jpg);


### PR DESCRIPTION
Change the orientation of the navbar to avoid overflow of images over the bar

Issue number #27 
